### PR TITLE
Revert blog listing to slug-based terminal layout, mobile stacking fixes

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -24,7 +24,7 @@ export default function AboutPage() {
         <h1 style={{ fontSize: '2rem', fontWeight: 800, letterSpacing: '-0.025em', marginBottom: 10 }}>
           About
         </h1>
-        <p style={{ fontSize: 14, color: 'var(--color-muted)', lineHeight: 1.65, maxWidth: 440, margin: 0 }}>
+        <p style={{ fontSize: 15, color: 'var(--color-muted)', lineHeight: 1.65, maxWidth: 440, margin: 0 }}>
           10+ years building distributed systems, platform infrastructure, and scalable backend architecture.
         </p>
       </section>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -27,7 +27,7 @@ export default async function BlogPage() {
         <h1 style={{ fontSize: '2rem', fontWeight: 800, letterSpacing: '-0.025em', marginBottom: 10 }}>
           Writing
         </h1>
-        <p style={{ fontSize: 14, color: 'var(--color-muted)', lineHeight: 1.65, maxWidth: 440, margin: 0 }}>
+        <p style={{ fontSize: 15, color: 'var(--color-muted)', lineHeight: 1.65, maxWidth: 440, margin: 0 }}>
           Deep dives on cloud infrastructure, distributed systems, backend architecture, and the web.
         </p>
       </section>

--- a/app/globals.css
+++ b/app/globals.css
@@ -115,11 +115,27 @@ body > main {
   grid-template-columns: 120px 1fr 70px 80px;
 }
 
+.blog-listing-row {
+  display: grid;
+  transition: background 0.15s;
+}
+.blog-listing-row .col-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.blog-listing-row:hover {
+  background: var(--color-surface);
+}
+.blog-listing-row:hover .blog-post-title {
+  color: #54B689 !important;
+}
+
 /* Mobile responsive overrides */
 @media (max-width: 640px) {
   /* Header row: hide on mobile (stacked rows are self-explanatory) */
   .blog-listing-header {
-    display: none;
+    display: none !important;
   }
 
   /* Post rows: stacked layout — title on top, meta below */
@@ -136,7 +152,7 @@ body > main {
     white-space: normal !important;
     overflow: visible !important;
     text-overflow: unset !important;
-    font-size: 13px !important;
+    font-size: 14px !important;
   }
 
   /* Meta row: category · date side by side below title */
@@ -277,6 +293,10 @@ a[aria-label]:hover {
 .home-post-row:hover {
   background: var(--color-surface);
 }
+.recent-post-row:hover .recent-post-title {
+  color: #54B689 !important;
+}
+
 .home-post-row:hover .home-post-title {
   color: #54B689 !important;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter, JetBrains_Mono } from 'next/font/google'
 import { Suspense } from 'react'
-import Script from 'next/script'
 import './globals.css'
 import Header from '@/components/layout/Header'
 import Footer from '@/components/layout/Footer'
@@ -32,15 +31,16 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head suppressHydrationWarning />
-      <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
-        <Script
-          id="theme-init"
-          strategy="beforeInteractive"
+      <head suppressHydrationWarning>
+        {/* eslint-disable-next-line @next/next/no-before-interactive-script-component */}
+        <script
+          suppressHydrationWarning
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var m=localStorage.getItem('pg-dev-portfolio-color-mode');if(m==='light'){document.documentElement.classList.remove('dark')}else{document.documentElement.classList.add('dark')}}catch(e){}})()`,
           }}
         />
+      </head>
+      <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
         <Terminal />
         <Suspense fallback={null}>
           <GoogleAnalytics />

--- a/components/blog/CategoryFilter.tsx
+++ b/components/blog/CategoryFilter.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
 import type { PostMeta } from '@/lib/posts'
 import { formatDate } from '@/lib/utils'
 
-const CATEGORY_FILTERS = [
+const FILTERS = [
   { key: 'all', label: 'all' },
   { key: 'devops', label: 'devops' },
   { key: 'databases', label: 'databases' },
@@ -19,35 +19,20 @@ interface Props {
 }
 
 export default function CategoryFilter({ posts, initialCategory = 'all' }: Props) {
-  const [activeCategory, setActiveCategory] = useState(initialCategory)
-  const [activeTag, setActiveTag] = useState<string | null>(null)
+  const [active, setActive] = useState(initialCategory)
 
-  const allTags = useMemo(() => {
-    const tagSet = new Set<string>()
-    posts.forEach(p => p.tags?.forEach(t => tagSet.add(t)))
-    return Array.from(tagSet).sort()
-  }, [posts])
-
-  const filtered = posts.filter(p => {
-    const categoryMatch = activeCategory === 'all' || p.category === activeCategory
-    const tagMatch = activeTag === null || p.tags?.includes(activeTag)
-    return categoryMatch && tagMatch
-  })
-
-  const handleTagClick = (tag: string) => {
-    setActiveTag(prev => prev === tag ? null : tag)
-  }
+  const filtered = active === 'all' ? posts : posts.filter(p => p.category === active)
 
   return (
     <div>
-      {/* Category chips */}
-      <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap', marginBottom: 10 }}>
-        {CATEGORY_FILTERS.map(({ key, label }) => {
-          const isActive = activeCategory === key
+      {/* Filter chips */}
+      <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap', marginBottom: 32 }}>
+        {FILTERS.map(({ key, label }) => {
+          const isActive = active === key
           return (
             <button
               key={key}
-              onClick={() => setActiveCategory(key)}
+              onClick={() => setActive(key)}
               style={{
                 fontFamily: 'var(--font-jetbrains-mono), monospace',
                 fontSize: 12,
@@ -70,65 +55,44 @@ export default function CategoryFilter({ posts, initialCategory = 'all' }: Props
         })}
       </div>
 
-      {/* Tag chips — desktop only */}
-      {allTags.length > 0 && (
-        <div className="blog-tag-row" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 28 }}>
-          {allTags.map(tag => {
-            const isActive = activeTag === tag
-            return (
-              <button
-                key={tag}
-                onClick={() => handleTagClick(tag)}
-                style={{
-                  fontFamily: 'var(--font-jetbrains-mono), monospace',
-                  fontSize: 12,
-                  padding: '3px 10px',
-                  borderRadius: 4,
-                  cursor: 'pointer',
-                  border: `1px solid ${isActive ? 'rgba(84,182,137,0.45)' : 'var(--color-border)'}`,
-                  color: isActive ? '#54B689' : 'var(--color-text-5)',
-                  background: isActive ? 'rgba(84,182,137,0.07)' : 'transparent',
-                  transition: 'all 0.15s',
-                }}
-              >
-                #{tag}
-              </button>
-            )
-          })}
-        </div>
-      )}
-
-      {/* Column headers — desktop only */}
+      {/* Column headers */}
       <div
-        className="blog-listing-grid blog-listing-header"
+        className="blog-listing-header"
         style={{
+          display: 'grid',
+          gridTemplateColumns: '120px 1fr 70px 80px',
           gap: '0 16px',
           padding: '0 6px 10px',
           borderBottom: '1px solid var(--color-border)',
           marginBottom: 2,
         }}
       >
-        <span className="col-category" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 10, color: 'var(--color-text-5)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
-          category
-        </span>
-        <span style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 10, color: 'var(--color-text-5)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
-          title
-        </span>
-        <span className="col-read" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 10, color: 'var(--color-text-5)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
-          read
-        </span>
-        <span className="col-date" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 10, color: 'var(--color-text-5)', textTransform: 'uppercase', letterSpacing: '0.08em', textAlign: 'right' }}>
-          published
-        </span>
+        {['category', 'title', 'read', 'published'].map((h, i) => (
+          <span
+            key={h}
+            style={{
+              fontFamily: 'var(--font-jetbrains-mono), monospace',
+              fontSize: 10,
+              color: 'var(--color-text-5)',
+              textTransform: 'uppercase' as const,
+              letterSpacing: '0.1em',
+              textAlign: i === 3 ? 'right' as const : 'left' as const,
+            }}
+          >
+            {h}
+          </span>
+        ))}
       </div>
 
       {/* Post rows */}
-      {filtered.length > 0 ? filtered.map((post) => (
+      {filtered.map((post) => (
         <Link
           key={post.slug}
           href={`/blog/${post.slug}`}
-          className="blog-listing-grid blog-listing-row"
+          className="blog-listing-row"
           style={{
+            display: 'grid',
+            gridTemplateColumns: '120px 1fr 70px 80px',
             gap: '0 16px',
             padding: '10px 6px',
             borderBottom: '1px solid var(--color-border)',
@@ -140,58 +104,46 @@ export default function CategoryFilter({ posts, initialCategory = 'all' }: Props
             transition: 'background 0.12s',
           }}
           onMouseEnter={e => {
-            const el = e.currentTarget as HTMLElement
-            el.style.background = 'var(--color-surface)'
-            const title = el.querySelector('[data-title]') as HTMLElement
+            ;(e.currentTarget as HTMLElement).style.background = 'var(--color-surface)'
+            const title = (e.currentTarget as HTMLElement).querySelector('[data-title]') as HTMLElement
             if (title) title.style.color = '#54B689'
           }}
           onMouseLeave={e => {
-            const el = e.currentTarget as HTMLElement
-            el.style.background = 'transparent'
-            const title = el.querySelector('[data-title]') as HTMLElement
+            ;(e.currentTarget as HTMLElement).style.background = 'transparent'
+            const title = (e.currentTarget as HTMLElement).querySelector('[data-title]') as HTMLElement
             if (title) title.style.color = 'var(--color-text-2)'
           }}
         >
-          <span className="col-category" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 12, color: '#54B689', whiteSpace: 'nowrap' }}>
+          <span className="col-category" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 12.5, color: 'rgba(84,182,137,0.65)', whiteSpace: 'nowrap' as const }}>
             {post.category}/
           </span>
           <span
             data-title=""
             className="col-title"
-            style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 13, color: 'var(--color-text-2)', transition: 'color 0.15s', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 14, color: 'var(--color-text-2)', transition: 'color 0.15s' }}
           >
             {post.slug}
           </span>
           <span className="col-read" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 12, color: 'var(--color-muted)' }}>
             {post.readingTime}
           </span>
-          <span className="col-date" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 12, color: 'var(--color-muted)', textAlign: 'right' }}>
+          <span className="col-date" style={{ fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 12, color: 'var(--color-muted)', textAlign: 'right' as const }}>
             {formatDate(post.publishedAt)}
           </span>
         </Link>
-      )) : (
-        <p style={{ padding: '24px 6px', fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 12, color: 'var(--color-text-5)' }}>
-          no posts found
-        </p>
-      )}
+      ))}
 
       {/* Footer */}
-      <p style={{ padding: '16px 6px 0', fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 12, color: 'var(--color-text-5)' }}>
-        <span style={{ color: 'rgba(84,182,137,0.75)' }}>{filtered.length}</span>
+      <p style={{ padding: '16px 6px 0', fontFamily: 'var(--font-jetbrains-mono), monospace', fontSize: 11.5, color: 'var(--color-text-5)' }}>
+        <span style={{ color: 'rgba(84,182,137,0.5)' }}>{filtered.length}</span>
         {' '}posts
-        {activeCategory === 'all' && !activeTag && (
+        {active === 'all' && (
           <>
             {' '}·{' '}
-            <span style={{ color: 'rgba(84,182,137,0.75)' }}>
+            <span style={{ color: 'rgba(84,182,137,0.5)' }}>
               {posts.reduce((sum, p) => sum + parseInt(p.readingTime), 0)}
             </span>
             {' '}min total
-          </>
-        )}
-        {activeTag && (
-          <>
-            {' '}tagged{' '}
-            <span style={{ color: 'rgba(84,182,137,0.75)' }}>#{activeTag}</span>
           </>
         )}
       </p>

--- a/components/home/RecentPosts.tsx
+++ b/components/home/RecentPosts.tsx
@@ -7,7 +7,7 @@ export default async function RecentPosts() {
   const total = allPosts.length
 
   return (
-    <section className="page-section" style={{ maxWidth: 880, margin: '0 auto', padding: '52px 24px 96px' }}>
+    <section style={{ maxWidth: 880, margin: '0 auto', padding: '52px 24px 96px' }}>
       {/* Section heading */}
       <div
         style={{
@@ -20,7 +20,7 @@ export default async function RecentPosts() {
         <div>
           <h2
             style={{
-              fontSize: '1.5rem',
+              fontSize: '1.25rem',
               fontWeight: 700,
               letterSpacing: '-0.015em',
               margin: 0,
@@ -35,7 +35,7 @@ export default async function RecentPosts() {
           style={{
             fontFamily: 'var(--font-jetbrains-mono), monospace',
             fontSize: 12,
-            color: '#54B689',
+            color: 'rgba(84,182,137,0.55)',
             textDecoration: 'none',
             transition: 'color 0.15s',
           }}
@@ -51,21 +51,23 @@ export default async function RecentPosts() {
           href={`/blog/${post.slug}`}
           className="home-post-row"
           style={{
+            display: 'grid',
+            gridTemplateColumns: '110px 1fr 72px',
             gap: '0 14px',
             padding: '9px 6px',
             borderBottom: i < recent.length - 1 ? '1px solid var(--color-border)' : 'none',
             cursor: 'pointer',
             textDecoration: 'none',
             color: 'inherit',
+            alignItems: 'baseline',
             borderRadius: 4,
           }}
         >
           <span
-            className="home-post-category"
             style={{
               fontFamily: 'var(--font-jetbrains-mono), monospace',
               fontSize: 12,
-              color: '#54B689',
+              color: 'rgba(84,182,137,0.6)',
               whiteSpace: 'nowrap',
             }}
           >
@@ -75,7 +77,7 @@ export default async function RecentPosts() {
             className="home-post-title"
             style={{
               fontFamily: 'var(--font-jetbrains-mono), monospace',
-              fontSize: 13,
+              fontSize: 14,
               color: 'var(--color-text-2)',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
@@ -86,10 +88,9 @@ export default async function RecentPosts() {
             {post.slug}
           </span>
           <span
-            className="home-post-date"
             style={{
               fontFamily: 'var(--font-jetbrains-mono), monospace',
-              fontSize: 12,
+              fontSize: 11.5,
               color: 'var(--color-muted)',
               textAlign: 'right',
             }}
@@ -104,7 +105,7 @@ export default async function RecentPosts() {
         <span
           style={{
             fontFamily: 'var(--font-jetbrains-mono), monospace',
-            fontSize: 12,
+            fontSize: 11.5,
             color: 'var(--color-text-5)',
           }}
         >


### PR DESCRIPTION
- Restore original slug-based terminal directory layout for blog listing and home recent posts
- Hide column headers on mobile, stack rows vertically for readability
- Fix inline style vs CSS specificity conflict for mobile title wrapping
- Bump page description font size to 15px on About and Writing pages
- Remove // latest writing label from home recent posts section